### PR TITLE
[7일차] SimpleJpaRepository 분석 / Persistable 구현하여 오버라이딩하기.

### DIFF
--- a/jiyoul/data-jpa/data-jpa/src/main/java/study/datajpa/entity/Item.java
+++ b/jiyoul/data-jpa/data-jpa/src/main/java/study/datajpa/entity/Item.java
@@ -1,0 +1,37 @@
+package study.datajpa.entity;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.domain.Persistable;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.Id;
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Item implements Persistable<String> {
+    @Id
+    private String id;
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+    public Item(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public boolean isNew() {
+        return createdDate == null;
+    }
+
+}


### PR DESCRIPTION
Persistable로 isNew를 재정의 하여 새로운 객체인지 판단하는 로직 변경하는건 기존에 공부하였어서 복습함.

isNew할때 새로운 객체인지 확인 할 시에
식별자가 자바 기본 타입일 때 0 으로 판단하는건 처음 배움.

@GenerateValue는 엔티티매니저가 persist를 해야 그때 id를 생성함.

id를 직접 넣어서 save()를 해야 할 경우에는
@CreatedDate를 사용한 등록시간과 조합하면 편리하게 isNew를 재정의 할 수 있음.